### PR TITLE
Add support for local model directory in FashionCLIP

### DIFF
--- a/fashion_clip/fashion_clip.py
+++ b/fashion_clip/fashion_clip.py
@@ -158,7 +158,13 @@ class FashionCLIP:
             model = CLIPModel.from_pretrained(name, use_auth_token=auth_token)
             preprocessing = CLIPProcessor.from_pretrained(name, use_auth_token=auth_token)
             hash = _model_processor_hash(name, model, preprocessing)
-
+            
+        # else if name is folder, assume it's a HF model and local installation
+        elif os.path.isdir(name):
+            model = CLIPModel.from_pretrained(name)
+            preprocessing = CLIPProcessor.from_pretrained(name)
+            hash = _model_processor_hash(name, model, preprocessing)
+            
         # else it doesn't use HF, assume using OpenAI CLiP
         else:
             if os.path.isfile(name):


### PR DESCRIPTION
### Pull Request Description

#### Summary

This pull request adds a new conditional block to the **_load_model** function to handle cases where the  **name** parameter is a directory. This enhancement allows the function to load a Hugging Face (HF) model from a local directory, improving the flexibility and usability of the model loading process.

#### Changes

- Added an 
```
elif os.path.isdir(name)
```
 block to the  **_load_model** function.
- Within this block, the function assumes that the directory contains a Hugging Face model and processor.

#### Rationale

Previously, the  **_load_model** function only handled known HF models, HF repositories, and OpenAI CLIP models. This enhancement allows users to specify a local directory containing a Hugging Face model, making the function more versatile and accommodating various use cases.

#### Code Example

```python
# else if name is folder, assume it's a HF model and local installation
elif os.path.isdir(name):
    model = CLIPModel.from_pretrained(name)
    preprocessing = CLIPProcessor.from_pretrained(name)
    hash = _model_processor_hash(name, model, preprocessing)
```
